### PR TITLE
Force docker push to upload all tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,4 +44,4 @@ runs:
 
     - name: Upload image to registry
       shell: bash
-      run: docker push ${{ steps.image_url.outputs.value }}
+      run: docker push -a ${{ steps.image_url.outputs.value }}


### PR DESCRIPTION
Add `-a` to force `docker push` to upload all tags of the built image